### PR TITLE
Add more configs

### DIFF
--- a/.circleci/extended/heroku-deploy.yml
+++ b/.circleci/extended/heroku-deploy.yml
@@ -3,10 +3,12 @@
 version: 2.1
 
 orbs:
-  # The Node.js orb contains a set of prepackaged CircleCI configuration you can utilize
-  # Orbs reduce the amount of configuration required for common tasks.
-  # See the orb documentation here: https://circleci.com/developer/orbs/orb/circleci/node
   node: circleci/node@4.1
+  # The heroku orb contains a set of prepackaged CircleCI configuration you can utilize to deploy applications to heroku
+  # Orbs reduce the amount of configuration required for common tasks.
+  # See the orb documentation here: https://circleci.com/developer/orbs/orb/circleci/heroku
+  # NOTE: Environment variables containing the necessary secrets can be setup in the circleci UI
+  # See here https://circleci.com/docs/2.0/env-vars/#setting-an-environment-variable-in-a-project
   heroku: circleci/heroku@1.2
 
 workflows:

--- a/.circleci/extended/heroku-deploy.yml
+++ b/.circleci/extended/heroku-deploy.yml
@@ -7,7 +7,7 @@ orbs:
   # The heroku orb contains a set of prepackaged CircleCI configuration you can utilize to deploy applications to heroku
   # Orbs reduce the amount of configuration required for common tasks.
   # See the orb documentation here: https://circleci.com/developer/orbs/orb/circleci/heroku
-  # NOTE: Environment variables containing the necessary secrets can be setup in the circleci UI
+  # NOTE: Environment variables containing the necessary secrets can be setup in the CircleCI UI
   # See here https://circleci.com/docs/2.0/env-vars/#setting-an-environment-variable-in-a-project
   heroku: circleci/heroku@1.2
 

--- a/.circleci/extended/orb-free.yml
+++ b/.circleci/extended/orb-free.yml
@@ -1,0 +1,26 @@
+version: 2.1
+
+jobs:
+  test:
+    docker:
+      - image: cimg/node:15.1
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - node-deps-v1-{{ .Branch }}-{{checksum "package-lock.json"}}
+      - run:
+          name: install packages
+          command: npm ci
+      - save_cache:
+          key: node-deps-v1-{{ .Branch }}-{{checksum "package-lock.json"}}
+          paths:
+            - ~/.npm
+      - run:
+          name: Run Tests
+          command: npm run test
+
+workflows:
+  orb-free-workflow:
+    jobs:
+      - test

--- a/.circleci/extended/orb-free.yml
+++ b/.circleci/extended/orb-free.yml
@@ -7,6 +7,8 @@ jobs:
     steps:
       - checkout
       - restore_cache:
+        # See the configuration reference documentation for more details on using restore_cache and save_cache steps
+        # https://circleci.com/docs/2.0/configuration-reference/?section=reference#save_cache
           keys:
             - node-deps-v1-{{ .Branch }}-{{checksum "package-lock.json"}}
       - run:

--- a/.circleci/extended/orb-test-job.yml
+++ b/.circleci/extended/orb-test-job.yml
@@ -1,0 +1,10 @@
+# This config is equivalent to both the '.circleci/extended/orb-free.yml' and the base '.circleci/config.yml'
+version: 2.1
+
+orbs:
+  node: circleci/node@4.1
+
+workflows:
+  sample:
+    jobs:
+      - node/test

--- a/.circleci/extended/orb-test-job.yml
+++ b/.circleci/extended/orb-test-job.yml
@@ -7,4 +7,6 @@ orbs:
 workflows:
   sample:
     jobs:
-      - node/test
+      - node/test:
+          # this is the node version to use for the `cimg/node` tag
+          version: 15.1

--- a/.circleci/extended/orb-test-job.yml
+++ b/.circleci/extended/orb-test-job.yml
@@ -9,4 +9,4 @@ workflows:
     jobs:
       - node/test:
           # this is the node version to use for the `cimg/node` tag
-          version: 15.1
+          version: "15.1"

--- a/.circleci/extended/orb-test-job.yml
+++ b/.circleci/extended/orb-test-job.yml
@@ -8,5 +8,7 @@ workflows:
   sample:
     jobs:
       - node/test:
-          # this is the node version to use for the `cimg/node` tag
           version: "15.1"
+          # This is the node version to use for the `cimg/node` tag
+          # Relevant tags can be found on the CircleCI Developer Hub
+          # https://circleci.com/developer/images/image/cimg/node

--- a/.circleci/extended/orb-test-matrix.yml
+++ b/.circleci/extended/orb-test-matrix.yml
@@ -2,6 +2,8 @@ version: 2.1
 
 orbs:
   node: circleci/node@4.1
+  # The Node.js orb contains a set of prepackaged CircleCI configuration you can utilize
+  # See the orb's test job here: https://circleci.com/developer/orbs/orb/circleci/node#jobs-test
 
 workflows:
   sample:
@@ -10,3 +12,7 @@ workflows:
           matrix:
             parameters:
               version: ["15.1", "lts", "12.21"]
+          # For more information about matrix testing see the detailed blog post:
+          # https://circleci.com/blog/circleci-matrix-jobs/
+          # or the configuration reference:
+          # https://circleci.com/docs/2.0/configuration-reference/?section=reference#matrix-requires-version-21

--- a/.circleci/extended/orb-test-matrix.yml
+++ b/.circleci/extended/orb-test-matrix.yml
@@ -6,7 +6,6 @@ orbs:
 workflows:
   sample:
     jobs:
-      - test:
       - node/test:
           matrix:
             parameters:

--- a/.circleci/extended/orb-test-matrix.yml
+++ b/.circleci/extended/orb-test-matrix.yml
@@ -1,0 +1,13 @@
+version: 2.1
+
+orbs:
+  node: circleci/node@4.1
+
+workflows:
+  sample:
+    jobs:
+      - test:
+      - node/test:
+          matrix:
+            parameters:
+              version: ["15.1", "lts", "12.21"]

--- a/.circleci/extended/s3-publish.yml
+++ b/.circleci/extended/s3-publish.yml
@@ -12,20 +12,6 @@ orbs:
   # See here https://circleci.com/docs/2.0/env-vars/#setting-an-environment-variable-in-a-project
   aws-s3: circleci/aws-s3@2.0
 
-jobs:
-  s3-publish:
-    docker:
-      - image: cimg/base:stable
-    steps:
-      - attach_workspace:
-            # this adds the dist directory to the workspace, which by default is /home/circleci/project/
-            # see the persist_to_workspace step below in the node/test post-steps
-            at: dist
-      - aws-s3/copy:
-          from: dist/
-          to: s3://sample-app-vue
-          arguments: --recursive
-
 workflows:
   sample:
     jobs:
@@ -34,15 +20,7 @@ workflows:
           # after the node/test job completes, build the dist packages and save them to a workspace
           post-steps:
             - run: npm run build
-            # For more information on persisting data between workspace see the configuration reference guide:
-            # https://circleci.com/docs/2.0/configuration-reference/#persist_to_workspace
-            # and the following concepts page: https://circleci.com/docs/2.0/concepts/#caches-workspaces-and-artifacts
-            - persist_to_workspace:
-                # this will save all the contents in the local `dist` directory
-                root: dist
-                paths:
-                  - ./*
-      - s3-publish:
-          requires:
-            - node/test
-
+            - aws-s3/copy:
+                from: dist/
+                to: s3://sample-app-vue
+                arguments: --recursive

--- a/.circleci/extended/s3-publish.yml
+++ b/.circleci/extended/s3-publish.yml
@@ -5,7 +5,7 @@ version: 2.1
 
 orbs:
   node: circleci/node@4.1
-  # The S3 orb is will setup the aws-cli and quickly copy or sync anything to s3.
+  # The S3 orb will setup the aws-cli and quickly copy or sync anything to s3.
   # Orbs reduce the amount of configuration required for common tasks.
   # See the orb documentation here: https://circleci.com/developer/orbs/orb/circleci/aws-s3
   # NOTE: Environment variables containing the necessary secrets can be setup in the CircleCI UI
@@ -19,6 +19,7 @@ jobs:
     steps:
       - attach_workspace:
             # this adds the dist directory to the workspace, which by default is /home/circleci/project/
+            # see the persist_to_workspace step below in the node/test post-steps
             at: dist
       - aws-s3/copy:
           from: dist/
@@ -30,9 +31,12 @@ workflows:
     jobs:
       - node/test:
           version: "15.1"
-          # after the test complete, build the dist packages and save them to a workspace
+          # after the node/test job completes, build the dist packages and save them to a workspace
           post-steps:
             - run: npm run build
+            # For more information on persisting data between workspace see the configuration reference guide:
+            # https://circleci.com/docs/2.0/configuration-reference/#persist_to_workspace
+            # and the following concepts page: https://circleci.com/docs/2.0/concepts/#caches-workspaces-and-artifacts
             - persist_to_workspace:
                 # this will save all the contents in the local `dist` directory
                 root: dist

--- a/.circleci/extended/s3-publish.yml
+++ b/.circleci/extended/s3-publish.yml
@@ -1,6 +1,6 @@
 # This config uses the `.circleci/extended/orb-test.yml` as its base, and then publishes the app to S3.
 # The workflow contained here demonstrates a practical application of `post-steps`
-# and using workspace persistence 
+# and using workspace persistence
 version: 2.1
 
 orbs:
@@ -18,9 +18,9 @@ jobs:
       - image: cimg/base:stable
     steps:
       - attach_workspace:
-            at: /tmp/dist
+            at: dist
       - aws-s3/copy:
-          from: /tmp/dist
+          from: dist
           to: s3://sample-apps/vue
 
 workflows:
@@ -32,8 +32,8 @@ workflows:
           post-steps:
             - run: npm run build
             - persist_to_workspace:
-                root: /tmp/dist
+                root: dist
                 paths:
-                  - dist/
+                  - ./*
       - s3-publish
 

--- a/.circleci/extended/s3-publish.yml
+++ b/.circleci/extended/s3-publish.yml
@@ -20,8 +20,9 @@ jobs:
       - attach_workspace:
             at: dist
       - aws-s3/copy:
-          from: dist
-          to: s3://sample-apps/vue
+          from: dist/
+          to: s3://sample-app-vue
+          arguments: --recursive
 
 workflows:
   sample:

--- a/.circleci/extended/s3-publish.yml
+++ b/.circleci/extended/s3-publish.yml
@@ -8,7 +8,7 @@ orbs:
   # The S3 orb is will setup the aws-cli and quickly copy or sync anything to s3.
   # Orbs reduce the amount of configuration required for common tasks.
   # See the orb documentation here: https://circleci.com/developer/orbs/orb/circleci/aws-s3
-  # NOTE: Environment variables containing the necessary secrets can be setup in the circleci UI
+  # NOTE: Environment variables containing the necessary secrets can be setup in the CircleCI UI
   # See here https://circleci.com/docs/2.0/env-vars/#setting-an-environment-variable-in-a-project
   aws-s3: circleci/aws-s3@2.0
 
@@ -18,6 +18,7 @@ jobs:
       - image: cimg/base:stable
     steps:
       - attach_workspace:
+            # this adds the dist directory to the workspace, which by default is /home/circleci/project/
             at: dist
       - aws-s3/copy:
           from: dist/
@@ -33,6 +34,7 @@ workflows:
           post-steps:
             - run: npm run build
             - persist_to_workspace:
+                # this will save all the contents in the local `dist` directory
                 root: dist
                 paths:
                   - ./*

--- a/.circleci/extended/s3-publish.yml
+++ b/.circleci/extended/s3-publish.yml
@@ -1,0 +1,39 @@
+# This config uses the `.circleci/extended/orb-test.yml` as its base, and then publishes the app to S3.
+# The workflow contained here demonstrates a practical application of `post-steps`
+# and using workspace persistence 
+version: 2.1
+
+orbs:
+  node: circleci/node@4.1
+  # The S3 orb is will setup the aws-cli and quickly copy or sync anything to s3.
+  # Orbs reduce the amount of configuration required for common tasks.
+  # See the orb documentation here: https://circleci.com/developer/orbs/orb/circleci/aws-s3
+  # NOTE: Environment variables containing the necessary secrets can be setup in the circleci UI
+  # See here https://circleci.com/docs/2.0/env-vars/#setting-an-environment-variable-in-a-project
+  aws-s3: circleci/aws-s3@2.0
+
+jobs:
+  s3-publish:
+    docker:
+      - image: cimg/base:stable
+    steps:
+      - attach_workspace:
+            at: /tmp/dist
+      - aws-s3/copy:
+          from: /tmp/dist
+          to: s3://sample-apps/vue
+
+workflows:
+  sample:
+    jobs:
+      - node/test:
+          version: "15.1"
+          # after the test complete, build the dist packages and save them to a workspace
+          post-steps:
+            - run: npm run build
+            - persist_to_workspace:
+                root: /tmp/dist
+                paths:
+                  - dist/
+      - s3-publish
+

--- a/.circleci/extended/s3-publish.yml
+++ b/.circleci/extended/s3-publish.yml
@@ -35,5 +35,7 @@ workflows:
                 root: dist
                 paths:
                   - ./*
-      - s3-publish
+      - s3-publish:
+          requires:
+            - node/test
 

--- a/.github/workflows/config-variants.yml
+++ b/.github/workflows/config-variants.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       matrix:
         # TODO add an action workflow to ensure every file in .circleci/extended appears in this list
-        configfile: ["heroku-deploy", "orb-free", "orb-test-job"]
+        configfile: ["heroku-deploy", "orb-free", "orb-test-job", "orb-test-matrix"]
     steps:
     - name: checkout
       uses: actions/checkout@v2

--- a/.github/workflows/config-variants.yml
+++ b/.github/workflows/config-variants.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       matrix:
         # TODO add an action workflow to ensure every file in .circleci/extended appears in this list
-        configfile: ["heroku-deploy", "orb-free", "orb-test-job", "orb-test-matrix"]
+        configfile: ["heroku-deploy", "orb-free", "orb-test-job", "orb-test-matrix", "s3-publish"]
     steps:
     - name: checkout
       uses: actions/checkout@v2

--- a/.github/workflows/config-variants.yml
+++ b/.github/workflows/config-variants.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       matrix:
         # TODO add an action workflow to ensure every file in .circleci/extended appears in this list
-        configfile: ["heroku-deploy", "orb-free"]
+        configfile: ["heroku-deploy", "orb-free", "orb-test-job"]
     steps:
     - name: checkout
       uses: actions/checkout@v2

--- a/.github/workflows/config-variants.yml
+++ b/.github/workflows/config-variants.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       matrix:
         # TODO add an action workflow to ensure every file in .circleci/extended appears in this list
-        configfile: ["heroku-deploy"]
+        configfile: ["heroku-deploy", "orb-free"]
     steps:
     - name: checkout
       uses: actions/checkout@v2


### PR DESCRIPTION
Adding additional configs to demonstrate a few general use cases for node and the node orb, as well as a simple deployment example to S3

1. orb-free.yml - speaks for itself, no orbs
2. orb-test-job.yml - uses the orb test job to demo what's in orb-free.yml
3. orb-test-matrix.yml - this should provide an example for testing against multiple versions 
4. s3-publish.yml - meant to demonstrate publishing to an s3 bucket, which I know to be a lazy way devs will deploy js libraries